### PR TITLE
Override ackAfterHandle

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,8 @@ build('kafka-common-lib', 'docker-host') {
         javaLibPipeline = load("build_utils/jenkins_lib/pipeJavaLib.groovy")
     }
 
+    env.skipDtrack = true
+
     def buildImageTag = "fcf116dd775cc2e91bffb6a36835754e3f2d5321"
     javaLibPipeline(buildImageTag)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,6 @@ build('kafka-common-lib', 'docker-host') {
         javaLibPipeline = load("build_utils/jenkins_lib/pipeJavaLib.groovy")
     }
 
-    env.skipDtrack = true
-
     def buildImageTag = "fcf116dd775cc2e91bffb6a36835754e3f2d5321"
     javaLibPipeline(buildImageTag)
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <java.version>8</java.version>
         <lombok.version>1.18.20</lombok.version>
         <kafka.clients.version>2.8.0</kafka.clients.version>
-        <spring-kafka.version>2.7.0</spring-kafka.version>
+        <spring-kafka.version>2.7.2</spring-kafka.version>
         <damsel.version>1.431-2f62a8c</damsel.version>
         <machinegun-proto.version>1.18-d814d69</machinegun-proto.version>
         <woody.thrift.version>[1.1.21,)</woody.thrift.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>8</java.version>
-        <lombok.version>1.18.4</lombok.version>
-        <kafka.clients.version>2.6.0</kafka.clients.version>
-        <spring-kafka.version>2.5.6.RELEASE</spring-kafka.version>
+        <lombok.version>1.18.20</lombok.version>
+        <kafka.clients.version>2.8.0</kafka.clients.version>
+        <spring-kafka.version>2.7.0</spring-kafka.version>
         <damsel.version>1.431-2f62a8c</damsel.version>
         <machinegun-proto.version>1.18-d814d69</machinegun-proto.version>
         <woody.thrift.version>[1.1.21,)</woody.thrift.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
 
     <artifactId>kafka-common-lib</artifactId>
-    <version>0.1.7</version>
+    <version>0.1.8</version>
 
     <name>Kafka common lib</name>
     <description>Kafka serializers/deserializers</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 
     <parent>
         <groupId>com.rbkmoney</groupId>
-        <artifactId>parent</artifactId>
-        <version>1.0.5</version>
+        <artifactId>library-parent-pom</artifactId>
+        <version>1.0.3</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/src/main/java/com/rbkmoney/kafka/common/exception/KafkaProduceException.java
+++ b/src/main/java/com/rbkmoney/kafka/common/exception/KafkaProduceException.java
@@ -16,7 +16,11 @@ public class KafkaProduceException extends RuntimeException {
         super(cause);
     }
 
-    public KafkaProduceException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    public KafkaProduceException(
+            String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/src/main/java/com/rbkmoney/kafka/common/exception/KafkaSerializationException.java
+++ b/src/main/java/com/rbkmoney/kafka/common/exception/KafkaSerializationException.java
@@ -9,7 +9,11 @@ public class KafkaSerializationException extends RuntimeException {
         super(message, cause);
     }
 
-    public KafkaSerializationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    public KafkaSerializationException(
+            String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
 

--- a/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepBatchErrorHandler.java
+++ b/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepBatchErrorHandler.java
@@ -1,6 +1,7 @@
 package com.rbkmoney.kafka.common.exception.handler;
 
 import com.rbkmoney.machinegun.eventsink.MachineEvent;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -13,6 +14,9 @@ import static com.rbkmoney.kafka.common.util.LogUtil.toSummaryString;
 
 @Slf4j
 public class SeekToCurrentWithSleepBatchErrorHandler extends SeekToCurrentBatchErrorHandler {
+
+    @Setter
+    private boolean ackAfterHandle = false;
 
     private final Integer sleepTimeSeconds;
 
@@ -43,7 +47,7 @@ public class SeekToCurrentWithSleepBatchErrorHandler extends SeekToCurrentBatchE
 
     @Override
     public boolean isAckAfterHandle() {
-        return false;
+        return this.ackAfterHandle;
     }
 
     private void sleepBeforeRetry() {

--- a/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepBatchErrorHandler.java
+++ b/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepBatchErrorHandler.java
@@ -27,9 +27,14 @@ public class SeekToCurrentWithSleepBatchErrorHandler extends SeekToCurrentBatchE
     }
 
     @Override
-    public void handle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer, MessageListenerContainer container) {
+    public void handle(
+            Exception thrownException,
+            ConsumerRecords<?, ?> data,
+            Consumer<?, ?> consumer,
+            MessageListenerContainer container) {
         log.error(String.format("Records commit failed, size=%d, %s", data.count(),
-                toSummaryString((ConsumerRecords<String, MachineEvent>) data)), thrownException);
+                toSummaryString((ConsumerRecords<String, MachineEvent>) data)
+        ), thrownException);
 
         sleepBeforeRetry();
 

--- a/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepBatchErrorHandler.java
+++ b/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepBatchErrorHandler.java
@@ -36,6 +36,11 @@ public class SeekToCurrentWithSleepBatchErrorHandler extends SeekToCurrentBatchE
         super.handle(thrownException, data, consumer, container);
     }
 
+    @Override
+    public boolean isAckAfterHandle() {
+        return false;
+    }
+
     private void sleepBeforeRetry() {
         try {
             Thread.sleep(TimeUnit.SECONDS.toMillis(sleepTimeSeconds));

--- a/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepErrorHandler.java
+++ b/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepErrorHandler.java
@@ -27,7 +27,11 @@ public class SeekToCurrentWithSleepErrorHandler extends SeekToCurrentErrorHandle
     }
 
     @Override
-    public void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer, MessageListenerContainer container) {
+    public void handle(
+            Exception thrownException,
+            List<ConsumerRecord<?, ?>> records,
+            Consumer<?, ?> consumer,
+            MessageListenerContainer container) {
         log.error("Records commit failed", thrownException);
         this.sleepBeforeRetry();
         super.handle(thrownException, records, consumer, container);
@@ -40,7 +44,7 @@ public class SeekToCurrentWithSleepErrorHandler extends SeekToCurrentErrorHandle
 
     private void sleepBeforeRetry() {
         try {
-            Thread.sleep(TimeUnit.SECONDS.toMillis((long)this.sleepTimeSeconds));
+            Thread.sleep(TimeUnit.SECONDS.toMillis((long) this.sleepTimeSeconds));
         } catch (InterruptedException var2) {
             Thread.currentThread().interrupt();
         }

--- a/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepErrorHandler.java
+++ b/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepErrorHandler.java
@@ -24,6 +24,7 @@ public class SeekToCurrentWithSleepErrorHandler extends SeekToCurrentErrorHandle
 
     public SeekToCurrentWithSleepErrorHandler(int sleepTimeSeconds, int maxFailures) {
         super(new FixedBackOff(0, maxFailures == -1 ? UNLIMITED_ATTEMPTS : (long) maxFailures - 1));
+        super.setAckAfterHandle(false);
         this.sleepTimeSeconds = sleepTimeSeconds;
     }
 

--- a/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepErrorHandler.java
+++ b/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepErrorHandler.java
@@ -33,6 +33,11 @@ public class SeekToCurrentWithSleepErrorHandler extends SeekToCurrentErrorHandle
         super.handle(thrownException, records, consumer, container);
     }
 
+    @Override
+    public boolean isAckAfterHandle() {
+        return false;
+    }
+
     private void sleepBeforeRetry() {
         try {
             Thread.sleep(TimeUnit.SECONDS.toMillis((long)this.sleepTimeSeconds));

--- a/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepErrorHandler.java
+++ b/src/main/java/com/rbkmoney/kafka/common/exception/handler/SeekToCurrentWithSleepErrorHandler.java
@@ -18,6 +18,7 @@ public class SeekToCurrentWithSleepErrorHandler extends SeekToCurrentErrorHandle
     private final Integer sleepTimeSeconds;
 
     public SeekToCurrentWithSleepErrorHandler() {
+        super.setAckAfterHandle(false);
         this.sleepTimeSeconds = 5;
     }
 
@@ -35,11 +36,6 @@ public class SeekToCurrentWithSleepErrorHandler extends SeekToCurrentErrorHandle
         log.error("Records commit failed", thrownException);
         this.sleepBeforeRetry();
         super.handle(thrownException, records, consumer, container);
-    }
-
-    @Override
-    public boolean isAckAfterHandle() {
-        return false;
     }
 
     private void sleepBeforeRetry() {

--- a/src/main/java/com/rbkmoney/kafka/common/loader/PreloadListener.java
+++ b/src/main/java/com/rbkmoney/kafka/common/loader/PreloadListener.java
@@ -4,6 +4,10 @@ import org.apache.kafka.clients.consumer.Consumer;
 
 public interface PreloadListener<K, T> {
 
-    void preloadToLastOffsetInPartition(Consumer<K, T> consumer, String topic, int partition, java.util.function.Consumer<T> handleConsumer);
+    void preloadToLastOffsetInPartition(
+            Consumer<K, T> consumer,
+            String topic,
+            int partition,
+            java.util.function.Consumer<T> handleConsumer);
 
 }

--- a/src/main/java/com/rbkmoney/kafka/common/loader/PreloadListenerImpl.java
+++ b/src/main/java/com/rbkmoney/kafka/common/loader/PreloadListenerImpl.java
@@ -29,7 +29,11 @@ public class PreloadListenerImpl<K, T> implements PreloadListener<K, T> {
     }
 
     @Override
-    public void preloadToLastOffsetInPartition(Consumer<K, T> consumer, String topic, int partition, java.util.function.Consumer<T> handleConsumer) {
+    public void preloadToLastOffsetInPartition(
+            Consumer<K, T> consumer,
+            String topic,
+            int partition,
+            java.util.function.Consumer<T> handleConsumer) {
         TopicPartition topicPartition = new TopicPartition(topic, partition);
         List<TopicPartition> topics = Collections.singletonList(topicPartition);
         consumer.assign(topics);

--- a/src/main/java/com/rbkmoney/kafka/common/retry/ConfigurableRetryPolicy.java
+++ b/src/main/java/com/rbkmoney/kafka/common/retry/ConfigurableRetryPolicy.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryPolicy;
-import org.springframework.retry.context.RetryContextSupport;
 import org.springframework.util.ClassUtils;
 
 import java.util.Map;
@@ -20,8 +19,9 @@ public class ConfigurableRetryPolicy implements RetryPolicy {
         this(maxAttempts, retryableExceptions, false, false);
     }
 
-    public ConfigurableRetryPolicy(int maxAttempts, Map<Class<? extends Throwable>, Boolean> retryableExceptions,
-                                   boolean traverseCauses, boolean defaultValue) {
+    public ConfigurableRetryPolicy(
+            int maxAttempts, Map<Class<? extends Throwable>, Boolean> retryableExceptions,
+            boolean traverseCauses, boolean defaultValue) {
         this.maxAttempts = maxAttempts;
         this.retryableClassifier = new BinaryExceptionClassifier(retryableExceptions, defaultValue);
         this.retryableClassifier.setTraverseCauses(traverseCauses);
@@ -51,12 +51,6 @@ public class ConfigurableRetryPolicy implements RetryPolicy {
         ((SimpleRetryContext) context).registerThrowable(throwable);
     }
 
-    private static class SimpleRetryContext extends RetryContextSupport {
-        public SimpleRetryContext(RetryContext parent) {
-            super(parent);
-        }
-    }
-
     private boolean retryForException(Throwable ex) {
         return retryableClassifier.classify(ex);
     }
@@ -66,3 +60,4 @@ public class ConfigurableRetryPolicy implements RetryPolicy {
         return ClassUtils.getShortName(getClass()) + "[maxAttempts=" + maxAttempts + "]";
     }
 }
+

--- a/src/main/java/com/rbkmoney/kafka/common/retry/SimpleRetryContext.java
+++ b/src/main/java/com/rbkmoney/kafka/common/retry/SimpleRetryContext.java
@@ -1,0 +1,10 @@
+package com.rbkmoney.kafka.common.retry;
+
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.context.RetryContextSupport;
+
+class SimpleRetryContext extends RetryContextSupport {
+    public SimpleRetryContext(RetryContext parent) {
+        super(parent);
+    }
+}

--- a/src/main/java/com/rbkmoney/kafka/common/util/LogUtil.java
+++ b/src/main/java/com/rbkmoney/kafka/common/util/LogUtil.java
@@ -38,14 +38,25 @@ public class LogUtil {
 
         ConsumerRecord firstRecord = records.get(0);
         ConsumerRecord lastRecord = records.get(records.size() - 1);
-        LongSummaryStatistics keySizeSummary = records.stream().mapToLong(ConsumerRecord::serializedKeySize).summaryStatistics();
-        LongSummaryStatistics valueSizeSummary = records.stream().mapToLong(ConsumerRecord::serializedValueSize).summaryStatistics();
-        return String.format("topic='%s', partition=%d, offset={%d...%d}, createdAt={%s...%s}, keySize={min=%d, max=%d, avg=%s}, valueSize={min=%d, max=%d, avg=%s}",
-                firstRecord.topic(), firstRecord.partition(),
-                firstRecord.offset(), lastRecord.offset(),
-                Instant.ofEpochMilli(firstRecord.timestamp()), Instant.ofEpochMilli(lastRecord.timestamp()),
-                keySizeSummary.getMin(), keySizeSummary.getMax(), keySizeSummary.getAverage(),
-                valueSizeSummary.getMin(), valueSizeSummary.getMax(), valueSizeSummary.getAverage()
+        LongSummaryStatistics keySizeSummary =
+                records.stream().mapToLong(ConsumerRecord::serializedKeySize).summaryStatistics();
+        LongSummaryStatistics valueSizeSummary =
+                records.stream().mapToLong(ConsumerRecord::serializedValueSize).summaryStatistics();
+        return String.format(
+                "topic='%s', partition=%d, offset={%d...%d}, createdAt={%s...%s}, keySize={min=%d, max=%d, avg=%s}, " +
+                "valueSize={min=%d, max=%d, avg=%s}",
+                firstRecord.topic(),
+                firstRecord.partition(),
+                firstRecord.offset(),
+                lastRecord.offset(),
+                Instant.ofEpochMilli(firstRecord.timestamp()),
+                Instant.ofEpochMilli(lastRecord.timestamp()),
+                keySizeSummary.getMin(),
+                keySizeSummary.getMax(),
+                keySizeSummary.getAverage(),
+                valueSizeSummary.getMin(),
+                valueSizeSummary.getMax(),
+                valueSizeSummary.getAverage()
         );
     }
 

--- a/src/test/java/com/rbkmoney/kafka/common/loader/PreloadListenerImplTest.java
+++ b/src/test/java/com/rbkmoney/kafka/common/loader/PreloadListenerImplTest.java
@@ -17,8 +17,10 @@ public class PreloadListenerImplTest {
     private static final String TOPIC = "the_topic";
     private static final int PARTITION = 0;
     private MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-    private PreloadListenerImpl<String, String> preloadListener = new PreloadListenerImpl<>(3,
-            new ExponentialBackOff(100L, 1.5));
+    private PreloadListenerImpl<String, String> preloadListener = new PreloadListenerImpl<>(
+            3,
+            new ExponentialBackOff(100L, 1.5)
+    );
 
     @Test
     public void preloadToLastOffsetInPartition() {

--- a/src/test/java/com/rbkmoney/kafka/common/retry/ConfigurableRetryPolicyTest.java
+++ b/src/test/java/com/rbkmoney/kafka/common/retry/ConfigurableRetryPolicyTest.java
@@ -5,15 +5,19 @@ import org.junit.Test;
 import org.springframework.retry.context.RetryContextSupport;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class ConfigurableRetryPolicyTest {
 
     @Test
     public void infiniteRetryPolicyTest() {
-        ConfigurableRetryPolicy configurableRetryPolicy = new ConfigurableRetryPolicy(-1,
-                new HashMap<Class<? extends Throwable>, Boolean>() {{
-                    put(IllegalAccessException.class, true);
-                }});
+        Map<Class<? extends Throwable>, Boolean> errorClassifierMap = new HashMap<>();
+        errorClassifierMap.put(IllegalAccessException.class, true);
+
+        ConfigurableRetryPolicy configurableRetryPolicy = new ConfigurableRetryPolicy(
+                -1,
+                errorClassifierMap
+        );
 
         Assert.assertEquals(-1, configurableRetryPolicy.getMaxAttempts());
 
@@ -29,10 +33,12 @@ public class ConfigurableRetryPolicyTest {
 
     @Test
     public void finiteRetryPolicyTest() {
-        ConfigurableRetryPolicy configurableRetryPolicy = new ConfigurableRetryPolicy(2,
-                new HashMap<Class<? extends Throwable>, Boolean>() {{
-                    put(IllegalAccessException.class, true);
-                }});
+        Map<Class<? extends Throwable>, Boolean> errorClassifierMap = new HashMap<>();
+        errorClassifierMap.put(IllegalAccessException.class, true);
+        ConfigurableRetryPolicy configurableRetryPolicy = new ConfigurableRetryPolicy(
+                2,
+                errorClassifierMap
+        );
 
         Assert.assertEquals(2, configurableRetryPolicy.getMaxAttempts());
 
@@ -67,10 +73,11 @@ public class ConfigurableRetryPolicyTest {
         retryContextWithEndedRetryCount.registerThrowable(new IllegalAccessException());
         retryContextWithEndedRetryCount.registerThrowable(new IllegalAccessException());
         retryContextWithEndedRetryCount.registerThrowable(new IllegalAccessException());
-        if (infinite)
+        if (infinite) {
             Assert.assertTrue(configurableRetryPolicy.canRetry(retryContextWithEndedRetryCount));
-        else
+        } else {
             Assert.assertFalse(configurableRetryPolicy.canRetry(retryContextWithEndedRetryCount));
+        }
     }
 
 }


### PR DESCRIPTION
Сейчас у новой kafka библиотеки пропал метод setAckOnError(false), который мы использовали. Ему пришёл на замену "setAckAfterHandle(false)" у обработчика.